### PR TITLE
fix: update skiprows parameter in CSV conversion

### DIFF
--- a/convert_csv_to_parquet.py
+++ b/convert_csv_to_parquet.py
@@ -3,7 +3,7 @@ def to_parquet(filename): #function header
     """
     Convert a csv to a parquet file.
     """
-    df = pd.read_csv(filename, header=0, skiprows=[1,2], encoding="latin") #read in the .csv file
+    df = pd.read_csv(filename, header=0, skiprows=[1], encoding="latin") #read in the .csv file
     print("reading csv... header: 0 | skiprows: [1,2] | encoding: latin") #list the .csv file reader settings
     df.to_parquet(filename.replace(".csv", ".parquet")) #write the date to a .parquet file
     print("Converted csv to parquet") #print success message


### PR DESCRIPTION
Adjusts the skiprows parameter in the CSV to Parquet conversion function to only skip the first row. This change improves the accuracy of the data being read from the CSV file.