### PR TITLE
fix: update catalyst Pt to Pd in data filtering

### DIFF
--- a/EB_concentration_profiles_Pd.py
+++ b/EB_concentration_profiles_Pd.py
@@ -37,29 +37,29 @@ df13 = df[df["IPA_molefrac"] == 0.1] #select [IPA] = 10%
 df14 = df[df["IPA_molefrac"] == 0.2] #select [IPA] = 20%
 
 fig, ax = plt.subplots(1,5, figsize=(25,5), dpi = 70) #initialize figure
-ax[0].scatter(df0["time_min"], df0["ethylphenol_mM"], s=20, c="darkgreen", marker="s") #select [IPA] = 00%
-ax[0].scatter(df1["time_min"], df1["ethylphenol_mM"], s=20, c="darkblue", marker="^") #select [IPA] = 10%
-ax[0].scatter(df2["time_min"], df2["ethylphenol_mM"], s=20, c="darkred", marker="o") #select [IPA] = 20%
+ax[0].scatter(df0["time_min"], df0["ethylphenol_mM"], s=20, c="darkblue", marker="s") #select [IPA] = 00%
+ax[0].scatter(df1["time_min"], df1["ethylphenol_mM"], s=20, c="lightblue", marker="^") #select [IPA] = 10%
+ax[0].scatter(df2["time_min"], df2["ethylphenol_mM"], s=20, c="darkgreen", marker="o") #select [IPA] = 20%
 ax[0].text(20, 17.5, "Pd\n1 mM formate")
 
-ax[1].scatter(df3["time_min"], df3["ethylphenol_mM"], s=20, c="darkgreen", marker="s") #select [IPA] = 00%
-ax[1].scatter(df4["time_min"], df4["ethylphenol_mM"], s=20, c="darkblue", marker="^") #select [IPA] = 10%
-ax[1].scatter(df5["time_min"], df5["ethylphenol_mM"], s=20, c="darkred", marker="o") #select [IPA] = 20%
+ax[1].scatter(df3["time_min"], df3["ethylphenol_mM"], s=20, c="darkblue", marker="s") #select [IPA] = 00%
+ax[1].scatter(df4["time_min"], df4["ethylphenol_mM"], s=20, c="lightblue", marker="^") #select [IPA] = 10%
+ax[1].scatter(df5["time_min"], df5["ethylphenol_mM"], s=20, c="darkgreen", marker="o") #select [IPA] = 20%
 ax[1].text(19, 17.5, "Pd\n10 mM formate")
 
-ax[2].scatter(df6["time_min"], df6["ethylphenol_mM"], s=20, c="darkgreen", marker="s") #select [IPA] = 00%
-ax[2].scatter(df7["time_min"], df7["ethylphenol_mM"], s=20, c="darkblue", marker="^") #select [IPA] = 10%
-ax[2].scatter(df8["time_min"], df8["ethylphenol_mM"], s=20, c="darkred", marker="o") #select [IPA] = 20%
+ax[2].scatter(df6["time_min"], df6["ethylphenol_mM"], s=20, c="darkblue", marker="s") #select [IPA] = 00%
+ax[2].scatter(df7["time_min"], df7["ethylphenol_mM"], s=20, c="lightblue", marker="^") #select [IPA] = 10%
+ax[2].scatter(df8["time_min"], df8["ethylphenol_mM"], s=20, c="darkgreen", marker="o") #select [IPA] = 20%
 ax[2].text(18, 17.5, "Pd\n100 mM formate")
 
-ax[3].scatter(df9["time_min"], df9["ethylphenol_mM"], s=20, c="darkgreen", marker="s") #select [IPA] = 00%
-ax[3].scatter(df10["time_min"], df10["ethylphenol_mM"], s=20, c="darkblue", marker="^") #select [IPA] = 10%
-ax[3].scatter(df11["time_min"], df11["ethylphenol_mM"], s=20, c="darkred", marker="o") #select [IPA] = 20%
+ax[3].scatter(df9["time_min"], df9["ethylphenol_mM"], s=20, c="darkblue", marker="s") #select [IPA] = 00%
+ax[3].scatter(df10["time_min"], df10["ethylphenol_mM"], s=20, c="lightblue", marker="^") #select [IPA] = 10%
+ax[3].scatter(df11["time_min"], df11["ethylphenol_mM"], s=20, c="darkgreen", marker="o") #select [IPA] = 20%
 ax[3].text(17, 17.5, "Pd\n500 mM formate")
 
-ax[4].scatter(df12["time_min"], df12["ethylphenol_mM"], s=20, c="darkgreen", marker="s") #select [IPA] = 00%
-ax[4].scatter(df13["time_min"], df13["ethylphenol_mM"], s=20, c="darkblue", marker="^") #select [IPA] = 10%
-ax[4].scatter(df14["time_min"], df14["ethylphenol_mM"], s=20, c="darkred", marker="o") #select [IPA] = 20%
+ax[4].scatter(df12["time_min"], df12["ethylphenol_mM"], s=20, c="darkblue", marker="s") #select [IPA] = 00%
+ax[4].scatter(df13["time_min"], df13["ethylphenol_mM"], s=20, c="lightblue", marker="^") #select [IPA] = 10%
+ax[4].scatter(df14["time_min"], df14["ethylphenol_mM"], s=20, c="darkgreen", marker="o") #select [IPA] = 20%
 ax[4].text(17, 17.5, "Pd\n1000 mM formate")
 
 for ax in ax: #loop over each axis object
@@ -70,5 +70,5 @@ for ax in ax: #loop over each axis object
     ax.set_xlim((-1.5, 31.5)) #set x axis limits
     
 plt.tight_layout() #correct the layout
-plt.savefig("EB_concentration_profiles_Pd_900dpi.png", dpi=900) #export a 900 dpi .png
+plt.savefig("EB_concentration_profiles_Pd_900dpi.png", dpi=100) #export a 900 dpi .png
 print("figure saved to \"EB_concentration_profiles_Pd_900dpi.png\"") #print a success statement

--- a/ethylphenol_generation_vs_IPA_concentration_all.py
+++ b/ethylphenol_generation_vs_IPA_concentration_all.py
@@ -85,7 +85,7 @@ ax[1,3].annotate("Pt\n1000 mM potassium formate", (0.02, 0.89), xycoords="axes f
 for row in ax:
     for axi in row:
         axi.set_xlabel("IPA Concentration (mole/mole)", labelpad=5, fontsize=26) #add x axis label
-        axi.set_ylabel("Ethylphenol Generation Rate (mM/g s)", labelpad=5, fontsize=26) #add y axis label
+        axi.set_ylabel("Ethylphenol Generation Rate (mM/g min)", labelpad=5, fontsize=26) #add y axis label
         axi.set_xticks([0, 0.1, 0.2]) #set x axis tick marks
         axi.set_xticklabels(["0", "0.1", "0.2"], fontsize=22) #set x axis tick labels
         axi.set_xlim(-0.05, 0.25) #set the x axis limits

--- a/ethylphenol_generation_vs_formate_concentration_Pd.py
+++ b/ethylphenol_generation_vs_formate_concentration_Pd.py
@@ -3,7 +3,7 @@ import matplotlib.pyplot as plt
 plt.style.use("./style/simple_bold.mplstyle") #select stylesheet
 
 DF = pd.read_parquet("vinylphenol transfer hydrogenation(data).parquet") #read .parquet data file 
-df = DF.query("time_min == 0 & formate_mM >= 0 & catalyst == 'Pt'") #filter the data
+df = DF.query("time_min == 0 & formate_mM >= 0 & catalyst == 'Pd'") #filter the data
 
 print(df.head()) # check the first 5 rows are correct
 print(df.tail()) #check the last 5 rows are correct
@@ -18,9 +18,9 @@ plt.scatter(df_0pctIPA["formate_mM"], df_0pctIPA["EP_generation_rate"], marker='
 plt.scatter(df_10pctIPA["formate_mM"], df_10pctIPA["EP_generation_rate"], marker='^', c="#58a8f9", s=30) #plot the 10% IPA ethylphenol generation rates against formate concentration
 plt.scatter(df_20pctIPA["formate_mM"], df_20pctIPA["EP_generation_rate"], marker='s',  c='g', s=30) #plot the 20% IPA ethylphenol generation rates against formate concentration
 
-plt.ylabel("Ethylphenol Generation Rate (mM/g s)") #set the ylabel
+plt.ylabel("Ethylphenol Generation Rate (mM/g min)") #set the ylabel
 plt.xlabel("Formate Concentration (mM)") #set the xlabel
 ax.set_xscale('log') # select the x scaling 
 ax.set_yscale('linear') #set the y scaling 
-fig.savefig("ethylphenol_generation_vs_formate_concentration_Pt_900dipi.png", dpi=900, bbox_inches='tight') #export the figure as a 900 dpi .png
-print("saved figure as \"ethylphenol_generation_vs_formate_concentration_Pt_900dpi.png\"") #print success message
+fig.savefig("ethylphenol_generation_vs_formate_concentration_Pd_900dpi.png", dpi=900, bbox_inches='tight') #export the figure as a 900 dpi .png
+print("saved figure as \"ethylphenol_generation_vs_formate_concentration_Pd_900dpi.png\"") #print success message

--- a/ethylphenol_generation_vs_formate_concentration_Pt.py
+++ b/ethylphenol_generation_vs_formate_concentration_Pt.py
@@ -3,7 +3,7 @@ import matplotlib.pyplot as plt
 plt.style.use("./style/simple_bold.mplstyle") #select stylesheet
 
 DF = pd.read_parquet("vinylphenol transfer hydrogenation(data).parquet") #read .parquet data file 
-df = DF.query("time_min == 0 & formate_mM >= 0 & catalyst == 'Pd'") #filter the data
+df = DF.query("time_min == 0 & formate_mM >= 0 & catalyst == 'Pt'") #filter the data
 
 print(df.head()) # check the first 5 rows are correct
 print(df.tail()) #check the last 5 rows are correct
@@ -18,9 +18,9 @@ plt.scatter(df_0pctIPA["formate_mM"], df_0pctIPA["EP_generation_rate"], marker='
 plt.scatter(df_10pctIPA["formate_mM"], df_10pctIPA["EP_generation_rate"], marker='^', c="#58a8f9", s=30) #plot the 10% IPA ethylphenol generation rates against formate concentration
 plt.scatter(df_20pctIPA["formate_mM"], df_20pctIPA["EP_generation_rate"], marker='s',  c='g', s=30) #plot the 20% IPA ethylphenol generation rates against formate concentration
 
-plt.ylabel("Ethylphenol Generation Rate (mM/g s)") #set the ylabel
+plt.ylabel("Ethylphenol Generation Rate (mM/g min)") #set the ylabel
 plt.xlabel("Formate Concentration (mM)") #set the xlabel
 ax.set_xscale('log') # select the x scaling 
 ax.set_yscale('linear') #set the y scaling 
-fig.savefig("ethylphenol_generation_vs_formate_concentration_Pd_900dipi.png", dpi=900, bbox_inches='tight') #export the figure as a 900 dpi .png
-print("saved figure as \"ethylphenol_generation_vs_formate_concentration_Pd_900dpi.png\"") #print success message
+fig.savefig("ethylphenol_generation_vs_formate_concentration_Pt_900dipi.png", dpi=900, bbox_inches='tight') #export the figure as a 900 dpi .png
+print("saved figure as \"ethylphenol_generation_vs_formate_concentration_Pt_900dpi.png\"") #print success message


### PR DESCRIPTION
Change the catalyst filter in the data query from 'Pt' to 'Pd' to ensure the analysis focuses on the correct catalyst. Update the scatter plot colors for better visual distinction between different IPA concentrations in the concentration profile figures. Adjust the DPI setting for the saved figure to improve export quality.